### PR TITLE
Add blog to Nixos Summer Repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,18 +21,16 @@ jobs:
         nix-channel --add https://nixos.org/channels/nixpkgs-unstable
         nix-channel --update
 
-    - name: Installing NixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixUnstable
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        nix --version
-        cat /etc/nix/nix.conf
-        nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
-        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
-        echo "PATH=${PATH}" >> $GITHUB_ENV
+    - uses: cachix/install-nix-action@v12
+      with:
+        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210823_af94b54/install
+        extra_nix_config:
+          experimental-features = nix-command flakes
 
     - name: Building summer.nixos.org
       run: |
+        nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
+        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
         nix build
         mkdir build
         cp -RL ./result/* ./build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
         echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
         nix --version
         cat /etc/nix/nix.conf
+        nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
         PATH="$HOME/.nix-profile/bin:$PATH"
         echo "PATH=${PATH}" >> $GITHUB_ENV
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ jobs:
     - name: Checking out the repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        fetch-depth: 0
+        submodules: true
 
     - uses: cachix/install-nix-action@v12
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
         PATH="$PWD/nix/bin/:$PATH"
-        export $PATH
+        export PATH
         echo "PATH=${PATH}" >> $GITHUB_ENV
         nix --version
         nix build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,12 +23,12 @@ jobs:
 
     - name: Installing NixFlakes
       run: |
-        nix-env -iA nixpkgs.nixFlakes
+        nix-env -iA nixpkgs.nixUnstable
         echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
         nix --version
         cat /etc/nix/nix.conf
         nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
-        PATH="$HOME/.nix-profile/bin:$PATH"
+        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
         echo "PATH=${PATH}" >> $GITHUB_ENV
 
     - name: Building summer.nixos.org

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,10 @@ jobs:
     - name: Building summer.nixos.org
       run: |
         nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
-        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
+        PATH="$PWD/nix/bin/:$PATH"
+        export $PATH
+        echo "PATH=${PATH}" >> $GITHUB_ENV
+        nix --version
         nix build
         mkdir build
         cp -RL ./result/* ./build/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,7 @@ jobs:
     - name: Checking out the repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-
-    - name: Installing Nix
-      uses: cachix/install-nix-action@v12
-
-    - name: Install unstable channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
+        fetch-depth: 1
 
     - uses: cachix/install-nix-action@v12
       with:

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -20,7 +20,10 @@ jobs:
     - name: Building summer.nixos.org
       run: |
         nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
-        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
+        PATH="$PWD/nix/bin/:$PATH"
+        export $PATH
+        echo "PATH=${PATH}" >> $GITHUB_ENV
+        nix --version
         nix build
         mkdir build
         cp -RL ./result/* ./build/

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Installing NixFlakes
       run: |
-        nix-env -iA nixpkgs.nixFlakes
+        nix-env -iA nixpkgs.nixUnstable
         echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
         nix --version
         cat /etc/nix/nix.conf

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -19,18 +19,16 @@ jobs:
         nix-channel --add https://nixos.org/channels/nixpkgs-unstable
         nix-channel --update
 
-    - name: Installing NixFlakes
-      run: |
-        nix-env -iA nixpkgs.nixUnstable
-        echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
-        nix --version
-        cat /etc/nix/nix.conf
-        nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
-        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
-        echo "PATH=${PATH}" >> $GITHUB_ENV
+    - uses: cachix/install-nix-action@v12
+      with:
+        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210823_af94b54/install
+        extra_nix_config:
+          experimental-features = nix-command flakes
 
     - name: Building summer.nixos.org
       run: |
+        nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
+        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
         nix build
         mkdir build
         cp -RL ./result/* ./build/

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
         PATH="$PWD/nix/bin/:$PATH"
-        export $PATH
+        export PATH
         echo "PATH=${PATH}" >> $GITHUB_ENV
         nix --version
         nix build

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -9,7 +9,8 @@ jobs:
     - name: Checking out the repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        fetch-depth: 0
+        submodules: true
 
     - uses: cachix/install-nix-action@v12
       with:

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -25,7 +25,8 @@ jobs:
         echo 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf
         nix --version
         cat /etc/nix/nix.conf
-        PATH="$HOME/.nix-profile/bin:$PATH"
+        nix build "github:NixOS/nix?rev=1ec4efa6c82fb6d90887c21aa7c7c6f3c644dd65" -o nix
+        PATH="$PWD/nix/bin/:$HOME/.nix-profile/bin:$PATH"
         echo "PATH=${PATH}" >> $GITHUB_ENV
 
     - name: Building summer.nixos.org

--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -9,15 +9,7 @@ jobs:
     - name: Checking out the repository
       uses: actions/checkout@v2
       with:
-        fetch-depth: 0
-
-    - name: Installing Nix
-      uses: cachix/install-nix-action@v12
-
-    - name: Install unstable channel
-      run: |
-        nix-channel --add https://nixos.org/channels/nixpkgs-unstable
-        nix-channel --update
+        fetch-depth: 1
 
     - uses: cachix/install-nix-action@v12
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "blog_posts"]
+	path = blog_posts
+	url = git@github.com:ngi-nix/ngi_website_content.git

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,13 @@
             {
               path = "index.html";
             }
+            # TODO programatically generate these
+            {
+              path = "blog_posts/PerlDivingWithNix.html";
+            }
+            {
+              path = "index_blog.html";
+            }
           ];
         mkPage =
           { path

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       <div class="button-tray">
         <a class="button -primary" href="#update-2021-06-02">Applications are closed</a>
         <a class="button" href="#about">Learn more</a>
+        <a class="button" href="./index_blog.html">Blog</a>
       </div>
     </div>
   </div>

--- a/index_blog.html
+++ b/index_blog.html
@@ -1,0 +1,14 @@
+<section class="hero">
+  <div>
+    <div class="blurb">
+      <h1>The Summer of Nix Blog</h1>
+      <p>
+        A series of blog posts detailing the experiences of the Summer of Nix participants.
+      </p>
+      <!--TODO programatically generate-->
+      <div >
+        <a class="button -primary" href="perl_post.html">Perl Diving with Nix</a>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
I made an attempt at programatically generating blogposts to put on the SoN website. Here's the control flow:

1) User pushes to https://github.com/ngi-nix/ngi_website_content
2) Github workflow uses pandoc + nix to generate HTML from markdown.
3) HTML files are pushed to separate branch (`pandoc`)
4) nixos-summer repo references ngi_website_content/pandoc's HTML files as a submodule

I've added a index_blog.html as a landing page. Note: this only works with the bleeding edge `nix` compiler that has git submodule support (I've been testing off master). We'd need to edit the github workflows for this repo as well to use bleeding edge nix (I have not done this yet).