### PR TITLE
Update Copyright Year to 2024

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -43,7 +43,7 @@
             <h4>NixOS</h4>
             <div>
               <span>
-                Copyright © 2022 NixOS contributors
+                Copyright © 2024 NixOS contributors
               </span>
               <span>
               <a href="https://github.com/NixOS/nixos-summer#license">


### PR DESCRIPTION
resolves #49 

This pull request updates the copyright year in the footer of the website from 2022 to 2024. This change ensures that the website reflects its ongoing maintenance and relevance. 
If there are any additional changes or if something needs to be adjusted, please let me know!
